### PR TITLE
Add all required files for running 'nesfile' utility to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Nintendo Entertainment System NES 2.0 (.nes) file reader",
   "main": "nes-file.js",
   "files": [
-    "nes-file.js"
+    "nes-file.js",
+    "examples/cli.js",
+    "bin/*"
   ],
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
This should fix the installation from npm.

You can test it without uploading to the registry first, by running `npm pack` that creates `nes-file-2.0.0.tgz`, that in turn is locally installable via `npm i /path/to/nes-file-2.0.0.tgz`.